### PR TITLE
kit-metrics module

### DIFF
--- a/metrics/config.edn
+++ b/metrics/config.edn
@@ -1,0 +1,33 @@
+{:default
+ {:require-restart? true
+  :actions
+  {:assets     []
+   :injections [{:type   :edn
+                 :path   "deps.edn"
+                 :target [:deps]
+                 :action :merge
+                 :value  {io.github.kit-clj/kit-metrics {:mvn/version "1.0.1"}}}
+                {:type   :edn
+                 :path   "resources/system.edn"
+                 :target []
+                 :action :merge
+                 :value  {:metrics/prometheus {}}}
+                {:type   :edn
+                 :path   "resources/system.edn"
+                 :target [:handler/ring]
+                 :action :merge
+                 :value  {:metrics #ig/ref :metrics/prometheus}}
+                {:type   :edn
+                 :path   "resources/system.edn"
+                 :target [:reitit.routes/api]
+                 :action :merge
+                 :value  {:metrics #ig/ref :metrics/prometheus}}
+                {:type   :clj
+                 :path   "src/clj/<<sanitized>>/core.clj"
+                 :action :append-requires
+                 :value  ["[kit.edge.utils.metrics]"]}
+                {:type   :clj
+                 :path   "src/clj/<<sanitized>>/web/middleware/core.clj"
+                 :action :append-requires
+                 :value  ["[iapetos.collector.ring :as prometheus-ring]"]}
+                ]}}}

--- a/modules.edn
+++ b/modules.edn
@@ -3,6 +3,9 @@
  {:kit/html
   {:path "html"
    :doc "adds support for HTML templating using Selmer"}
+  :kit/metrics
+  {:path "metrics"
+   :doc "adds support for metrics using prometheus through iapetos"}
   :kit/sqlite
   {:path "sqlite"
    :doc "adds support for SQLite embedded database"}


### PR DESCRIPTION
Add kit/metrics module.

Behaves in the same way as `+metrics` profile, with the exception that it doesn't modify `wrap-base` function in `<<ns-name>>.web.middleware.core` package.