### PR TITLE
Remove superfluous :html from htmx home page

### DIFF
--- a/htmx/assets/src/ui.clj
+++ b/htmx/assets/src/ui.clj
@@ -9,15 +9,14 @@
 
 (defn home [request]
   (page
-   [:html
-    [:head
-     [:meta {:charset "UTF-8"}]
-     [:title "Htmx + Kit"]
-     [:script {:src "https://unpkg.com/htmx.org@1.7.0/dist/htmx.min.js" :defer true}]
-     [:script {:src "https://unpkg.com/hyperscript.org@0.9.5" :defer true}]]
-    [:body
-     [:h1 "Welcome to Htmx + Kit module"]
-     [:button {:hx-post "/clicked" :hx-swap "outerHTML"} "Click me!"]]]))
+   [:head
+    [:meta {:charset "UTF-8"}]
+    [:title "Htmx + Kit"]
+    [:script {:src "https://unpkg.com/htmx.org@1.7.0/dist/htmx.min.js" :defer true}]
+    [:script {:src "https://unpkg.com/hyperscript.org@0.9.5" :defer true}]]
+   [:body
+    [:h1 "Welcome to Htmx + Kit module"]
+    [:button {:hx-post "/clicked" :hx-swap "outerHTML"} "Click me!"]]))
 
 (defn clicked [request]
   (ui


### PR DESCRIPTION
An `:html` element is [already added by `hiccup.page/html5`](https://github.com/weavejester/hiccup/blob/master/src/hiccup/page.clj#L75), called in `<<ns-name>>.web.htmx/page`.