### PR TITLE
Make build-cljs step platform agnostic

### DIFF
--- a/cljs/config.edn
+++ b/cljs/config.edn
@@ -15,30 +15,37 @@
                  :action :append
                  :target [:body]
                  :value  [:script {:src "/js/app.js"}]}
-                 {:type :edn
-                  :path "deps.edn"
-                  :target [:paths]
-                  :action :append
-                  :value "src/cljs"}
+                {:type :edn
+                 :path "deps.edn"
+                 :target [:paths]
+                 :action :append
+                 :value "src/cljs"}
                 {:type :edn
                  :path "deps.edn"
                  :target [:aliases :dev :extra-paths]
                  :action :append
                  :value  "target/classes/cljsbuild"}
+                {:type   :edn
+                 :path   "deps.edn"
+                 :target [:aliases :build :deps]
+                 :action :merge
+                 :value  {babashka/fs {:mvn/version "0.1.11"}
+                          babashka/process {:mvn/version "0.3.11"}}}
                 {:type   :clj
                  :path   "build.clj"
                  :action :append-requires
-                 :value  ["[clojure.java.shell :refer [sh]]"]}
+                 :value  ["[babashka.fs :refer [copy-tree]]"
+                          "[babashka.process :refer [shell]]"]}
                 {:type   :clj
                  :path   "build.clj"
                  :action :append-build-task
                  :value  (defn build-cljs []
                            (println "npx shadow-cljs release app...")
                            (let [{:keys [exit]
-                                  :as   s} (sh "npx" "shadow-cljs" "release" "app")]
+                                  :as   s} (shell "npx shadow-cljs release app")]
                              (when-not (zero? exit)
                                (throw (ex-info "could not compile cljs" s)))
-                             (sh "cp" "-r" "target/classes/cljsbuild/public" "target/classes/")))}
+                             (copy-tree "target/classes/cljsbuild/public" "target/classes/")))}
                 {:type   :clj
                  :path   "build.clj"
                  :action :append-build-task-call


### PR DESCRIPTION
Fixes #9 

Use Babashka tools `copy-tree` and `shell` instead of `sh`