### PR TITLE
add missing muuntaja

### DIFF
--- a/htmx/assets/src/ui.clj
+++ b/htmx/assets/src/ui.clj
@@ -1,6 +1,7 @@
 (ns <<ns-name>>.web.routes.ui
   (:require
    [<<ns-name>>.web.middleware.exception :as exception]
+   [<<ns-name>>.web.middleware.formats :as formats]
    [<<ns-name>>.web.routes.utils :as utils]
    [<<ns-name>>.web.htmx :refer [ui page] :as htmx]
    [integrant.core :as ig]
@@ -30,7 +31,8 @@
 (defn route-data [opts]
   (merge
    opts
-   {:middleware 
+   {:muuntaja   formats/instance
+    :middleware
     [;; Default middleware for ui
      ;; query-params & form-params
      parameters/parameters-middleware


### PR DESCRIPTION
There is a bug in the htmx module.  Look at the exception handler [here](https://github.com/kit-clj/kit/blob/master/libs/deps-template/resources/io/github/kit_clj/kit/src/clj/web/middleware/exception.clj#L11-L14). It returns body as a map.  Therefore we need muuntaja to later convert that body map into a string after the exception is handled.