### PR TITLE
Add cide/cider-nrepl to dependencies

### DIFF
--- a/cljs/assets/shadow-cljs.edn
+++ b/cljs/assets/shadow-cljs.edn
@@ -2,6 +2,7 @@
  :source-paths ["src/cljs"]
  :dependencies [[binaryage/devtools "1.0.3"]
                 [nrepl "0.8.3"]
+                [cider/cider-nrepl "0.30.0"]
                 [reagent "1.1.0"]
                 [cljs-ajax "0.8.4"]]
  :builds       {:app {:target     :browser


### PR DESCRIPTION
Hey guys, I am new to Clojure, so, sorry if I misunderstood problem/solution

There was an issue with evaluating things within emacs while following official docs.
REPL was functioning just right, but I wasn't able to eval with C-c C-c. 

I found that root cause was missing cider-nrepl package in shadow-cljs, after adding it everything works just fine. However, I am not entirely sure if I put it into correct place