### PR TITLE
Store generated files in target/generated-sources

### DIFF
--- a/tailwind/assets/main.cljs
+++ b/tailwind/assets/main.cljs
@@ -4,7 +4,9 @@
     ["node:child_process" :as child-process]
     ["node-watch$default" :as watch-files]
     [promesa.core :as p]
-    ["recursive-readdir$default" :as recursive]))
+    ["recursive-readdir$default" :as recursive]
+    ["fs" :as fs]
+))
 
 (defn tailwind []
   (let [cp
@@ -45,7 +47,9 @@
            (let [files (filter src? files)]
              (if (empty? files)
                (js/console.error "No files found")
-               (p/do
+               (p/do 
+                (.mkdir fs "target/generated-sources/tailwind"
+                        #js {:recursive true} #(.error js/console %))
                 (p/all (map process/process-file files))
                 (when watch? (watch path))))))))
       (println "please provide path"))))

--- a/tailwind/assets/process.cljs
+++ b/tailwind/assets/process.cljs
@@ -121,7 +121,7 @@
 (defn spit [f s]
   (.writeFile
     fs
-    (format "tailwind/auto_%s.html" (.replaceAll f "/" "_"))
+    (format "target/generated-sources/tailwind/auto_%s.html" (.replaceAll f "/" "_"))
     s
     #()))
 

--- a/tailwind/assets/tailwind.config.js
+++ b/tailwind/assets/tailwind.config.js
@@ -1,6 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: ["./tailwind/**/*.{html,js}"],
+  content: ["./target/generated-sources/tailwind/**/*.{html,js}"],
   theme: {
     extend: {},
   },


### PR DESCRIPTION
This changes the Tailwind module to store its generated HTML files in the more standard (at least in Java land) target/generated-sources directory.

The main advantage is that the target directory is already in .gitignore, and that it separates the generated files from tailwind/input.css. (Though I personally have the latter in resources/css.)

@whamtet 