### PR TITLE
Add Datomic module

### DIFF
--- a/datomic/assets/src/datomic.clj
+++ b/datomic/assets/src/datomic.clj
@@ -1,0 +1,14 @@
+(ns <<ns-name>>.datomic
+  (:require [clojure.tools.logging :as log]
+            [datomic.api :as d]
+            [integrant.core :as ig]))
+
+(defmethod ig/init-key :db.datomic/conn
+  [_ {:keys [db-uri]}]
+  (when (d/create-database db-uri)
+    (log/info (str "Database " db-uri " created (didn't exist)")))
+  (d/connect db-uri))
+
+(defmethod ig/halt-key! :db.datomic/conn
+  [_ conn]
+  (d/release conn))

--- a/datomic/config.edn
+++ b/datomic/config.edn
@@ -1,0 +1,26 @@
+{:default
+ {:require-restart? true
+  :actions
+  {:assets [["assets/src/datomic.clj" "src/clj/<<sanitized>>/datomic.clj"]]
+   :injections
+   [{:action :merge
+     :path "resources/system.edn"
+     :target []
+     :type :edn
+     :value
+     {:db.datomic/conn
+      #profile
+       {:dev  {:db-uri #or [#env DATOMIC_DB_URI "datomic:dev://localhost:4334/<<name>>"]}
+        :test {:db-uri #or [#env DATOMIC_DB_URI_TEST "datomic:dev://localhost:4334/<<name>>_test"]}
+        :prod {:db-uri #env DATOMIC_DB_URI}}}}
+
+    {:action :merge
+     :path   "deps.edn"
+     :target [:deps]
+     :type   :edn
+     :value  {com.datomic/peer {:mvn/version "1.0.7075"}}}
+
+    {:action :append-requires
+     :path   "src/clj/<<sanitized>>/core.clj"
+     :type   :clj
+     :value  ["[<<ns-name>>.datomic]"]}]}}}

--- a/modules.edn
+++ b/modules.edn
@@ -44,4 +44,7 @@
    :doc "adds support for kit-Hato HTTP client"}
   :kit/codox
   {:path "codox"
-   :doc "adds support for codox"}}}
+   :doc "adds support for codox"}
+  :kit/datomic
+  {:path "datomic"
+   :doc "adds support for Datomic"}}}


### PR DESCRIPTION
This module allows for connecting to a Datomic transactor on system start. It adds the Datomic Peer (in-process) library, not Client. It does not provide a DB value right away (`(d/db conn)`) because it can confuse people, as every DB value is 'fixed' to a moment in time.