### PR TITLE
Add UIx profile to cljs module

### DIFF
--- a/cljs/assets/package.uix.json
+++ b/cljs/assets/package.uix.json
@@ -1,0 +1,10 @@
+{
+  "devDependencies": {
+    "shadow-cljs": "^2.22.9"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-refresh": "^0.14.0"
+  }
+}

--- a/cljs/assets/shadow-cljs.edn
+++ b/cljs/assets/shadow-cljs.edn
@@ -3,7 +3,6 @@
  :dependencies [[binaryage/devtools "1.0.3"]
                 [nrepl "0.8.3"]
                 [cider/cider-nrepl "0.30.0"]
-                [reagent "1.1.0"]
                 [cljs-ajax "0.8.4"]]
  :builds       {:app {:target     :browser
                       :output-dir "target/classes/cljsbuild/public/js"

--- a/cljs/assets/src/core.uix.cljs
+++ b/cljs/assets/src/core.uix.cljs
@@ -1,0 +1,20 @@
+(ns <<ns-name>>.core
+  (:require
+   [uix.core :refer [defui $]]
+   [uix.dom]))
+
+;; -------------------------
+;; Views
+
+(defui home-page []
+  ($ :div
+     ($ :h2 "Welcome to UIx!")))
+
+;; -------------------------
+;; Initialize app
+
+(defn ^:dev/after-load mount-root []
+  (uix.dom/render-root ($ home-page) (uix.dom/create-root (js/document.getElementById "app"))))
+
+(defn ^:export ^:dev/once init! []
+  (mount-root))

--- a/cljs/config.edn
+++ b/cljs/config.edn
@@ -1,10 +1,10 @@
 {:default
+ {:feature-requires [:base :reagent]}
+
+ :base
  {:require-restart? true
-  :requires [:kit/html]
   :actions
-  {:assets     [["assets/shadow-cljs.edn" "shadow-cljs.edn"]
-                ["assets/package.json"    "package.json"]
-                ["assets/src/core.cljs"   "src/cljs/<<sanitized>>/core.cljs"]]
+  {:assets     [["assets/shadow-cljs.edn" "shadow-cljs.edn"]]
    :injections [{:type   :html
                  :path   "resources/html/home.html"
                  :action :append
@@ -49,4 +49,33 @@
                 {:type   :clj
                  :path   "build.clj"
                  :action :append-build-task-call
-                 :value  (build-cljs)}]}}}
+                 :value  (build-cljs)}]}}
+ :reagent
+ {:requires [:kit/html]
+  :feature-requires [:base]
+
+  :actions
+  {:assets [["assets/src/core.cljs" "src/cljs/<<sanitized>>/core.cljs"]
+            ["assets/package.json"    "package.json"]]
+   :injections [{:type   :edn
+                 :path   "shadow-cljs.edn"
+                 :target [:dependencies]
+                 :action :append
+                 :value  [reagent "1.1.0"]}]}}
+
+ :uix
+ {:requires [:kit/html]
+  :feature-requires [:base]
+  :actions
+  {:assets [["assets/src/core.uix.cljs" "src/cljs/<<sanitized>>/core.cljs"]
+            ["assets/package.uix.json"    "package.json"]]
+   :injections [{:type   :edn
+                 :path   "shadow-cljs.edn"
+                 :target [:dependencies]
+                 :action :append
+                 :value  [com.pitch/uix.core  "1.1.0"]}
+                {:type :edn
+                 :path "shadow-cljs.edn"
+                 :target [:dependencies]
+                 :action :append
+                 :value [com.pitch/uix.dom  "1.1.0"]}]}}}


### PR DESCRIPTION
This extends the cljs module to use profiles for libs other than Reagent. I'm adding pitch-io's UIx here. I'm not sure how useful other people will find this, but I thought I'd open a PR just in case.

Also, I'm still a Clojure novice, so this more than likely can be simplified/done better. Duplicating the files isn't great, but I couldn't think of a better way.