### PR TITLE
spawn -> exec

### DIFF
--- a/tailwind/assets/main.cljs
+++ b/tailwind/assets/main.cljs
@@ -10,9 +10,8 @@
 
 (defn tailwind []
   (let [cp
-        (child-process/spawn
-         "npx"
-         #js ["tailwindcss" "-i" "./tailwind/input.css" "-o" "./resources/public/output.css"])]
+        (child-process/exec
+         "npx tailwindcss -i ./tailwind/input.css -o ./resources/public/output.css")]
     (-> cp
         .-stdout
         (.on "data" #(-> % .toString js/console.log)))


### PR DESCRIPTION
node's spawn fails on windows (possibly a node bug).  However exec works fine.  OSX / linux is unaffected.