### PR TITLE
Some fixes to the HTMX module

### DIFF
--- a/htmx/assets/src/htmx.clj
+++ b/htmx/assets/src/htmx.clj
@@ -4,12 +4,12 @@
    [hiccup.core :as h]
    [hiccup.page :as p]))
 
-(defn page [opts & content]
-  (-> (p/html5 opts content)
-      http-response/ok
-      (http-response/content-type "text/html")))
+(defmacro page [opts & content]
+  `(-> (p/html5 ~opts ~@content)
+       http-response/ok
+       (http-response/content-type "text/html")))
 
-(defn ui [opts & content]
-  (-> (h/html opts content)
-      http-response/ok
-      (http-response/content-type "text/html")))
+(defmacro ui [opts & content]
+  `(-> (str (h/html ~opts ~@content))
+       http-response/ok
+       (http-response/content-type "text/html")))

--- a/htmx/assets/src/htmx.clj
+++ b/htmx/assets/src/htmx.clj
@@ -9,7 +9,7 @@
        http-response/ok
        (http-response/content-type "text/html")))
 
-(defmacro ui [opts & content]
+(defmacro pagelet [opts & content]
   `(-> (str (h/html ~opts ~@content))
        http-response/ok
        (http-response/content-type "text/html")))

--- a/htmx/assets/src/ui.clj
+++ b/htmx/assets/src/ui.clj
@@ -19,7 +19,7 @@
     [:button {:hx-post "/clicked" :hx-swap "outerHTML"} "Click me!"]]))
 
 (defn clicked [request]
-  (ui
+  (pagelet
    [:div "Congratulations! You just clicked the button!"]))
 
 ;; Routes

--- a/htmx/assets/src/ui.clj
+++ b/htmx/assets/src/ui.clj
@@ -9,12 +9,11 @@
    [reitit.ring.middleware.parameters :as parameters]))
 
 (defn home [request]
-  (page
+  (page {:lang "en"}
    [:head
     [:meta {:charset "UTF-8"}]
     [:title "Htmx + Kit"]
-    [:script {:src "https://unpkg.com/htmx.org@1.9.10/dist/htmx.min.js" :defer true}]
-    [:script {:src "https://unpkg.com/hyperscript.org@0.9.12" :defer true}]]
+    [:script {:src "https://unpkg.com/htmx.org@2.0.4/dist/htmx.min.js" :defer true}]]
    [:body
     [:h1 "Welcome to Htmx + Kit module"]
     [:button {:hx-post "/clicked" :hx-swap "outerHTML"} "Click me!"]]))

--- a/htmx/config.edn
+++ b/htmx/config.edn
@@ -16,7 +16,7 @@
      :path   "deps.edn"
      :target [:deps]
      :action :merge
-     :value  {hiccup/hiccup {:mvn/version "2.0.0-RC3"}}}
+     :value  {hiccup/hiccup {:mvn/version "2.0.0-RC5"}}}
     {:type   :clj
      :path   "src/clj/<<sanitized>>/core.clj"
      :action :append-requires


### PR DESCRIPTION
I'm not converting `page` and `ui`  to macros in the interest of speed, but the previous versions didn't handle correctly the case when you pass an opts-map to the functions (since the spliced content is passed as a single parameter to html5 macros).
If you could `apply` a macro I would have gone for that, but don't know of any other obvious way to accomplish this.

Also, in the case of current Hiccup2 the `html` function returns a compiled representation, not a string. I don't think the former is a valid Ring response body type.

Re the last commit, I think 'ui' is too generic a name. 'Pagelet' actually seems to be an established term for these kind of partial pages (and it's sounds much cuter).
