### PR TITLE
ClojureScript Module Output Fix

### DIFF
--- a/cljs/assets/shadow-cljs.edn
+++ b/cljs/assets/shadow-cljs.edn
@@ -5,8 +5,13 @@
                 [cider/cider-nrepl "0.30.0"]
                 [cljs-ajax "0.8.4"]]
  :builds       {:app {:target     :browser
-                      :output-dir "target/classes/cljsbuild/public/js"
+                      :output-dir "resources/public/js"
                       :asset-path "/js"
                       :modules    {:app {:entries [<<ns-name>>.core]
                                          :init-fn <<ns-name>>.core/init!}}
-                      :devtools   {:after-load <<ns-name>>.core/mount-root}}}}
+                      :devtools   {:after-load <<ns-name>>.core/mount-root}}
+                :app-prod {:target     :browser
+                           :output-dir "target/classes/cljsbuild/public/js"
+                           :asset-path "/js"
+                           :modules    {:app {:entries [<<ns-name>>.core]
+                                              :init-fn <<ns-name>>.core/init!}}}}}

--- a/cljs/config.edn
+++ b/cljs/config.edn
@@ -40,11 +40,12 @@
                  :path   "build.clj"
                  :action :append-build-task
                  :value  (defn build-cljs []
-                           (println "npx shadow-cljs release app...")
+                           (println "npx shadow-cljs release app-prod...")
                            (let [{:keys [exit]
-                                  :as   s} (shell "npx shadow-cljs release app")]
+                                  :as   s} (shell "npx shadow-cljs release app-prod")]
                              (when-not (zero? exit)
                                (throw (ex-info "could not compile cljs" s)))
+                             (b/delete {:path "target/classes/public/js"})
                              (copy-tree "target/classes/cljsbuild/public" "target/classes/public")))}
                 {:type   :clj
                  :path   "build.clj"


### PR DESCRIPTION
This change updates the canonical `:kit/cljs` module so development and production builds use different Shadow build IDs and output directories.


Projects generated from the cljs module include this in `resources/html/home.html`:

```html
<div id="app"></div>
<script src="/js/app.js"></script>
```

That means the browser expects `/js/app.js` to exist as a served static asset.

In development, the `:app` build should therefore write to `resources/public/js` so `npx shadow-cljs watch app` produces files where the running app can serve them immediately.

For production, release output should not be written into source resources. Instead, a dedicated `:app-prod` build should write to `target/classes/cljsbuild/public/js`, and those compiled assets should then be copied into the packaged public resources tree.

## What changed

1. `cljs/assets/shadow-cljs.edn` now defines two builds:
   - `:app` -> `resources/public/js`
   - `:app-prod` -> `target/classes/cljsbuild/public/js`

2. `cljs/config.edn` now appends a production build task that runs:

```clojure
(shell "npx" "shadow-cljs" "release" "app-prod")
```

3. Before copying compiled assets, the build task removes stale JS output:

```clojure
(b/delete {:path "target/classes/public/js"})
```

This prevents repeated build failures such as `FileAlreadyExistsException` when files like `target/classes/public/js/manifest.edn` already exist from a previous run.

4. The build task keeps the existing copy step:

```clojure
(copy-tree "target/classes/cljsbuild/public" "target/classes/public")
```

This ensures the packaged application still contains `/js/app.js` and the related compiled cljs assets.